### PR TITLE
限制sitemap生成范围

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -37,6 +37,16 @@ $wgServer = "https://youshou.wiki";
 ## SEO规范网址
 $wgEnableCanonicalServerLink = true;
 
+## 限制sitemap生成范围
+$wgSitemapNamespaces = [
+    0,
+    4,  // Project
+    6,  // File
+    12, // Help
+    14, // Category
+    300 // Fanmade
+];
+
 ## iOS“添加到主页”指定图标
 $wgAppleTouchIcon = "/images/thumb/0/0c/Touch-icon.png/150px-Touch-icon.png";
 

--- a/maintenance/generateSitemap.php
+++ b/maintenance/generateSitemap.php
@@ -384,6 +384,7 @@ class GenerateSitemap extends Maintenance {
 				$entry = $this->fileEntry( $title->getCanonicalURL(), $date, $this->priority( $namespace ) );
 				$length += strlen( $entry );
 				$this->write( $this->file, $entry );
+				/*
 				// generate pages for language variants
 				if ( $langConverter->hasVariants() ) {
 					$variants = $langConverter->getVariants();
@@ -400,6 +401,7 @@ class GenerateSitemap extends Maintenance {
 						$this->write( $this->file, $entry );
 					}
 				}
+				*/
 			}
 
 			if ( $skippedNoindex > 0 ) {


### PR DESCRIPTION
我在`$wgSitemapNamespaces`中列出了我认为值得被搜索引擎收录的namespace。User命名空间其实也可以被收录，但目前已经被robots.txt排除了所以没有列出。没有排除Help是觉得用户可能会想通过外部搜索引擎找到站内帮助文档。

同时我也注释掉了mediawiki上游`generateSitemap.php`中添加各语言变体链接的功能，可以减小sitemap文件体积。