### PR TITLE
清理调试用代码

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -400,7 +400,6 @@ require_once "/www/wwwroot/mw-utils/YsArchives-Skins/LoadSkins.php";
 
 // debug only
 $wgReadOnly = false ;
-#$wgDebugLogGroups['pcd'] = '/www/wwwroot/mwlogs'
 // Use ?forceprofile=1 to generate a trace log, written to /w/logs/speedscope.json
 	/*
 if ( extension_loaded( 'excimer' ) && isset( $_GET['forceprofile'] ) ) {

--- a/includes/json/JsonCodec.php
+++ b/includes/json/JsonCodec.php
@@ -25,8 +25,6 @@ use FormatJson;
 use InvalidArgumentException;
 use JsonSerializable;
 use Wikimedia\Assert\Assert;
-use CacheTime;
-use MediaWiki\Json\JsonUnserializable;
 
 /**
  * Helper class to serialize/unserialize things to/from JSON.
@@ -89,20 +87,10 @@ class JsonCodec implements JsonUnserializer, JsonSerializer {
 	}
 
 	public function serialize( $value ) {
-		$valclass = get_class($value);
-		$v1 = $value instanceof JsonSerializable;
-		$v2 = $value instanceof CacheTime;
-		$v3 = $value instanceof JsonUnserializable;
 		if ( $value instanceof JsonSerializable ) {
-			wfDebugLog('pcd', "JC: calling jsonSerialize");
-			$value = $value->jsonSerialize();
-		} elseif ( $value instanceof CacheTime ) {
 			$value = $value->jsonSerialize();
 		}
 		$json = FormatJson::encode( $value, false, FormatJson::ALL_OK );
-		wfDebugLog('pcd', "JC: $valclass; $json");
-		wfDebugLog('pcd', "JsonSerializable $v1; CacheTime $v2; JsonUnserializable $v3");
-		usleep(1000);
 		if ( !$json ) {
 			// TODO: make it JsonException
 			throw new InvalidArgumentException(

--- a/includes/json/JsonUnserializableTrait.php
+++ b/includes/json/JsonUnserializableTrait.php
@@ -24,8 +24,6 @@ namespace MediaWiki\Json;
 trait JsonUnserializableTrait {
 
 	public function jsonSerialize(): array {
-		wfDebugLog('pcd', "JT::jsonSerialize");
-		usleep(2000);
 		return $this->annotateJsonForDeserialization(
 			$this->toJsonArray()
 		);

--- a/includes/parser/ParserOutput.php
+++ b/includes/parser/ParserOutput.php
@@ -2487,9 +2487,6 @@ class ParserOutput extends CacheTime implements ContentMetadataCollector {
 			$data['MaxAdaptiveExpiry'] = $this->mMaxAdaptiveExpiry;
 		}
 
-		$trunc_data = substr(json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE), 0, 35);
-		wfDebugLog('pcd', "ParserOutput: $trunc_data");
-
 		return $data;
 	}
 


### PR DESCRIPTION
https://github.com/TopRealm/SemanticMediaWiki/commit/c636a496b0eb5c1ca113be03eeddeca8f0b177e0 已移除了造成parser cache故障的元凶。故恢复mediawiki core被改动的代码到上游版本。

撤销 #27, #28, #29, #30。具体commit列表见本PR包含的commit message。